### PR TITLE
fix typo ("cotain")

### DIFF
--- a/src/assets/src/languages/torro-forms.pot
+++ b/src/assets/src/languages/torro-forms.pot
@@ -2530,7 +2530,7 @@ msgstr ""
 #, php-format
 msgid ""
 "This text appears on top of a form and shows the user which fields are "
-"required. The value has to cotain a %s to output the correct indicator."
+"required. The value has to contain a %s to output the correct indicator."
 msgstr ""
 
 #: src/modules/form-settings/module.php:92

--- a/src/src/modules/form-settings/module.php
+++ b/src/src/modules/form-settings/module.php
@@ -82,7 +82,7 @@ class Module extends Module_Base {
 				'tab'          => 'labels',
 				'type'         => 'text',
 				'label'        => __( 'Required fields text', 'torro-forms' ),
-				'description'  => __( 'This text appears on top of a form and shows the user which fields are required. The value has to cotain a %s to output the correct indicator.', 'torro-forms' ), //phpcs:ignore WordPress.WP.I18n.MissingTranslatorsComment
+				'description'  => __( 'This text appears on top of a form and shows the user which fields are required. The value has to contain a %s to output the correct indicator.', 'torro-forms' ), //phpcs:ignore WordPress.WP.I18n.MissingTranslatorsComment
 				'default'      => $this->get_default_required_fields_text(),
 				'wrap_classes' => array( 'has-torro-tooltip-description' ),
 			),


### PR DESCRIPTION
## Description
This fixes a typo, namely "cotain" → "contain". I edited the `.pot` file directly; I hope that's no problem.

Furthermore, I corrected some errors in the [German translation](https://translate.wordpress.org/projects/wp-plugins/torro-forms/stable/de/default/).

## Checklist:
- [N/A] My code is tested.
- [x] My code is backward-compatible with WordPress 4.8 and PHP 5.6.
- [x] My code follows the WordPress coding standards.
- [N/A] My code has proper inline documentation.
